### PR TITLE
Enable virtual keyboard, add startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Bundabergmixer 9000
+
+## Autostart
+Kopiere Code in Verzeichnis /home/pi/bundabergmixer_9000 und kopiere touchinterface.service nach /etc/systemd/system.
+`sudo systemctl daemon-reload` (Einmalig nach Kopieren der .service)
+`sudo systemctl enable touchinterface` (Um Autostart zu aktivieren)

--- a/main.py
+++ b/main.py
@@ -16,17 +16,9 @@ from kivy.clock import mainthread, Clock
 
 
 import json
-#Raspberry Pi Touchscreen:
 from kivy.config import Config
-Config.set('graphics', 'width', '800')
-Config.set('graphics', 'height', '480')
 
-
-
-
-	
-# 0 being off 1 being on as in true / false
-# you can use 0 or 1 && True or False
+Config.set('kivy', 'keyboard_mode', 'dock')
 Config.set('graphics', 'resizable', True)
 
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd /home/pi/bundabergmixer_9000/
+python3 main.py --config input:touch:mtdev,/dev/input/by-id/usb-Fondar_Fondar_USB_Touch_00000000001A-event-if00 --config graphics:show_cursor:0

--- a/touchinterface.service
+++ b/touchinterface.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Bundabergmixer 9000 Touchscreen UI
+
+[Service]
+ExecStart=/home/pi/bundabergmixer_9000/start.sh
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Installation instructions have been added to the README.
The virtual keyboard is always enabled (also on desktop), but the cursor
is only hidden on the raspberry pi when starting with the `start.sh`
shell script.